### PR TITLE
Make sure the localeIdentifier is passed correctly

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3+1
+
+* Make sure the supplied locale is respected (see issue [#10](https://github.com/Baseflow/flutter-geocoding/issues/10))
+
 ## 1.0.3
 
 * Make sure public types defined in the geocoding_platform_interface are also available from the geocoding package (see [#6](https://github.com/Baseflow/flutter-geocoding/issues/6)).

--- a/geocoding/android/src/main/java/com/baseflow/geocoding/MethodCallHandlerImpl.java
+++ b/geocoding/android/src/main/java/com/baseflow/geocoding/MethodCallHandlerImpl.java
@@ -79,7 +79,7 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
 
     private void onLocationFromAddress(MethodCall call, Result result) {
         final String address = call.argument("address");
-        final String languageTag = call.argument("locale");
+        final String languageTag = call.argument("localeIdentifier");
 
         if (address == null || address.isEmpty()) {
             result.error(
@@ -114,7 +114,7 @@ final class MethodCallHandlerImpl implements MethodCallHandler {
     private void onPlacemarkFromCoordinates(MethodCall call, Result result) {
         final double latitude = call.argument("latitude");
         final double longitude = call.argument("longitude");
-        final String languageTag = call.argument("locale");
+        final String languageTag = call.argument("localeIdentifier");
 
         try {
             final List<Address> addresses = geocoding.placemarkFromCoordinates(

--- a/geocoding/ios/Classes/GeocodingPlugin.m
+++ b/geocoding/ios/Classes/GeocodingPlugin.m
@@ -56,11 +56,11 @@
 }
 
 + (NSLocale*) parseLocale:(NSDictionary*)arguments {
-    if (arguments[@"locale"] == nil) {
+    if (arguments[@"localeIdentifier"] == nil) {
         return nil;
     }
     
-    return [[NSLocale alloc] initWithLocaleIdentifier:(NSString*) arguments[@"locale"]];
+    return [[NSLocale alloc] initWithLocaleIdentifier:(NSString*) arguments[@"localeIdentifier"]];
 }
 
 + (NSArray<NSDictionary *> *) toLocationResult:(NSArray<CLPlacemark *> *)placemarks {

--- a/geocoding/ios/geocoding.podspec
+++ b/geocoding/ios/geocoding.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'geocoding'
-  s.version          = '1.0.3'
+  s.version          = '1.0.3+1'
   s.summary          = 'A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/geocoding/lib/geocoding.dart
+++ b/geocoding/lib/geocoding.dart
@@ -44,4 +44,5 @@ Future<List<Placemark>> placemarkFromCoordinates(
     GeocodingPlatform.instance.placemarkFromCoordinates(
       latitude,
       longitude,
+      localeIdentifier: localeIdentifier,
     );

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 1.0.3
+version: 1.0.3+1
 homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Currently the `localeIdentifier` is not past correctly to the native side of the plugin.

### :new: What is the new behavior (if this is a feature change)?

Correctly pass the `localeIdentifier` parameter and act accordingly.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

1. Open the example app;
2. Pass a correctly locale identifier to the `placemarkFromCoordinates` and `locationFromAddress` methods;
3. Run the example app and verify the app displays the information in the correct locale.
 
### :memo: Links to relevant issues/docs

Fixes #10 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop