### PR TITLE
Fix documentation referring to old method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dependencies:
 
 ## API
 
-To translate an address into latitude and longitude coordinates you can use the `placemarkFromAddress` method:
+To translate an address into latitude and longitude coordinates you can use the `locationFromAddress` method:
 
 ``` dart
 import 'package:geocoding/geocoding.dart';


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
A documentation fix.

### :arrow_heading_down: What is the current behavior?
The method name in the documentation (README) refers to an outdated name.

### :new: What is the new behavior (if this is a feature change)?
It refers to the correct name.

### :boom: Does this PR introduce a breaking change?
No :+1: 