### PR TITLE
Filter on correct label

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -4,7 +4,7 @@
 daysUntilClose: 14
 
 # Label requiring a response
-responseRequiredLabel: "status: waiting for customer response"
+responseRequiredLabel: "status: needs more info"
 
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >


### PR DESCRIPTION
Make sure the no-response GitHub App filters on the correct "status: needs more info" label.