### PR TITLE
Add formattedAddress

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Added formattedAddress
+
 ## 2.0.0
 
 - Migrate to null safety.

--- a/geocoding/android/src/main/java/com/baseflow/geocoding/utils/AddressMapper.java
+++ b/geocoding/android/src/main/java/com/baseflow/geocoding/utils/AddressMapper.java
@@ -37,6 +37,14 @@ public class AddressMapper {
         placemark.put("subAdministrativeArea", address.getSubAdminArea());
         placemark.put("locality", address.getLocality());
         placemark.put("subLocality", address.getSubLocality());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i <= address.getMaxAddressLineIndex(); i++) {
+            if (i > 0) {
+                sb.append("\n");
+            }
+            sb.append(address.getAddressLine(i));
+        }
+        placemark.put("formattedAddress", sb.toString());
 
         return placemark;
     }

--- a/geocoding/ios/Classes/Extensions/CLPlacemarkExtensions.m
+++ b/geocoding/ios/Classes/Extensions/CLPlacemarkExtensions.m
@@ -13,17 +13,19 @@
 
 - (NSDictionary *)toPlacemarkDictionary {
     NSString* street = @"";
+    NSString* postalAddress = @"";
 
     if (@available(iOS 11.0, *)) {
         if (self.postalAddress != nil) {
             street = self.postalAddress.street;
+            CNPostalAddressFormatter *formatter = [[CNPostalAddressFormatter alloc]init];
+            postalAddress = [formatter stringFromPostalAddress:self.postalAddress];
         }
     } else if (@available(iOS 5.0, *)) {
         if (self.addressDictionary != nil) {
             street = [[self addressDictionary] objectForKey:(NSString *)kABPersonAddressStreetKey];
         }
     }
-    
     NSMutableDictionary<NSString *, NSObject *> *dict = [[NSMutableDictionary alloc] initWithDictionary:@{
         @"name": self.name == nil ? @"" : self.name,
         @"street": street == nil ? @"" : street,
@@ -36,6 +38,7 @@
         @"subAdministrativeArea": self.subAdministrativeArea == nil ? @"" : self.subAdministrativeArea,
         @"locality": self.locality == nil ? @"" : self.locality,
         @"subLocality": self.subLocality == nil ? @"" : self.subLocality,
+        @"formattedAddress": postalAddress,
     }];
     
     return dict;

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  geocoding_platform_interface: ^2.0.0
+  geocoding_platform_interface: ^2.0.1
 
 dev_dependencies:
   flutter_test:

--- a/geocoding_platform_interface/CHANGELOG.md
+++ b/geocoding_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Added formattedAddress
+
 ## 2.0.0
 
 - Migrate to null safety.

--- a/geocoding_platform_interface/lib/src/models/placemark.dart
+++ b/geocoding_platform_interface/lib/src/models/placemark.dart
@@ -18,6 +18,7 @@ class Placemark {
     this.subLocality,
     this.thoroughfare,
     this.subThoroughfare,
+    this.formattedAddress,
   });
 
   Placemark._({
@@ -32,6 +33,7 @@ class Placemark {
     this.subLocality,
     this.thoroughfare,
     this.subThoroughfare,
+    this.formattedAddress,
   });
 
   /// The name associated with the placemark.
@@ -67,6 +69,9 @@ class Placemark {
   /// Additional street address information for the placemark.
   final String? subThoroughfare;
 
+  /// Formatted Address.
+  final String? formattedAddress;
+
   @override
   bool operator ==(dynamic o) =>
       o is Placemark &&
@@ -80,7 +85,8 @@ class Placemark {
       o.subAdministrativeArea == subAdministrativeArea &&
       o.subLocality == subLocality &&
       o.subThoroughfare == subThoroughfare &&
-      o.thoroughfare == thoroughfare;
+      o.thoroughfare == thoroughfare &&
+      o.formattedAddress == formattedAddress;
 
   @override
   int get hashCode =>
@@ -94,7 +100,8 @@ class Placemark {
       subAdministrativeArea.hashCode ^
       subLocality.hashCode ^
       subThoroughfare.hashCode ^
-      thoroughfare.hashCode;
+      thoroughfare.hashCode ^
+      formattedAddress.hashCode;
 
   /// Converts a list of [Map] instances to a list of [Placemark] instances.
   static List<Placemark> fromMaps(dynamic message) {
@@ -126,6 +133,7 @@ class Placemark {
       subLocality: placemarkMap['subLocality'] ?? '',
       thoroughfare: placemarkMap['thoroughfare'] ?? '',
       subThoroughfare: placemarkMap['subThoroughfare'] ?? '',
+      formattedAddress: placemarkMap['formattedAddress'] ?? '',
     );
   }
 
@@ -143,6 +151,7 @@ class Placemark {
         'subLocality': subLocality,
         'thoroughfare': thoroughfare,
         'subThoroughfare': subThoroughfare,
+        'formattedAddress': formattedAddress,
       };
 
   @override
@@ -158,6 +167,7 @@ class Placemark {
       Locality: $locality,
       Sublocality: $subLocality,
       Thoroughfare: $thoroughfare,
-      Subthoroughfare: $subThoroughfare''';
+      Subthoroughfare: $subThoroughfare,
+      FormattedAddress: $formattedAddress''';
   }
 }

--- a/geocoding_platform_interface/pubspec.yaml
+++ b/geocoding_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geocoding plugin.
 homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Enhancement: added 'formattedAddress' 
Android is just as like #55 , but iOS fixed.

### :arrow_heading_down: What is the current behavior?
Formatted address does not provided.
It's very useful on several locales.
(In US. address represented as  "street city state postalcode country", but in Japan. it represented as "postalcode prefecture city addressnumber"
It's so complicated. We should leave it to OS.)

### :new: What is the new behavior (if this is a feature change)?
Formatted address are provided.


### :boom: Does this PR introduce a breaking change?
Perhaps in edge case(serializing or something like this), because member has been added.

### :bug: Recommendations for testing
I tested on iOS 14 and Android 11.
I don't have iOS 9 devices. 
If you have, please.

### :memo: Links to relevant issues/docs
Pull req. #55 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
(Just bumped, if breaking changes are so heavy, I'll bump it to 2.1.0)
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
(Sorry, I didn't find it out.)
- [x] I rebased onto current `master`.

