### PR TITLE
Upgrade compileSdkVersion to 31

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3
+- Upgrade compileSdkVersion to 31
+
 ## 2.0.2
 - Migrate maven repository from jcenter to mavenCentral
 

--- a/geocoding/README.md
+++ b/geocoding/README.md
@@ -28,11 +28,11 @@ To use this plugin, please follow the installation guide on the [official geocod
 >android.useAndroidX=true
 >android.enableJetifier=true
 >```
->2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 30:
+>2. Make sure you set the `compileSdkVersion` in your "android/app/build.gradle" file to 31:
 >
 >```
 >android {
->  compileSdkVersion 30
+>  compileSdkVersion 31
 >
 >  ...
 >}

--- a/geocoding/android/build.gradle
+++ b/geocoding/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16

--- a/geocoding/example/android/app/build.gradle
+++ b/geocoding/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     lintOptions {
         disable 'InvalidPackage'

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR fixes https://github.com/Baseflow/flutter-geocoding/issues/87 which prevents, Flutter apps compiling to Android SDK 31, to build.

### :arrow_heading_down: What is the current behavior?
Build fails for Flutter applications compiling for Android SDK 31

### :new: What is the new behavior (if this is a feature change)?
Build works fine for flutter applications compiling for Android SDK 31

### :boom: Does this PR introduce a breaking change?
Yes, current clients must also upgrade to `compileSdkVersion 31` on `android/app/build.gradle`, when using this version of `flutter-geocoding`

### :bug: Recommendations for testing
Run example app or any other application on Android device/emulator with `compileSdkVersion 31` on `android/app/build.gradle`

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting
- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
