### PR TITLE
Fix Android embedding deprecation warning

### DIFF
--- a/.github/workflows/app_facing_package.yaml
+++ b/.github/workflows/app_facing_package.yaml
@@ -32,16 +32,16 @@ jobs:
       # Make sure the stable version of Flutter is available
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'beta'
+          channel: 'stable'
 
-      # Download all Flutter packages the geocoding depends on
+      # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Format to ensure formatting is valid
       - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed lib
+        run: flutter format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
       
       # Run Flutter Analyzer

--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 2.0.3
-- Upgrade compileSdkVersion to 31
+
+- Upgrades `compileSdkVersion` to `31` on Android.
+- Resolves Android embedding deprecation warning.
 
 ## 2.0.2
-- Migrate maven repository from jcenter to mavenCentral
+
+- Migrate maven repository from jcenter to mavenCentral.
 
 ## 2.0.1
 

--- a/geocoding/android/src/main/java/com/baseflow/geocoding/GeocodingPlugin.java
+++ b/geocoding/android/src/main/java/com/baseflow/geocoding/GeocodingPlugin.java
@@ -4,7 +4,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * Plugin implementation that uses the new {@code io.flutter.embedding} package.
@@ -20,10 +19,11 @@ public final class GeocodingPlugin implements FlutterPlugin {
    * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
    * package.
    *
-   * <p>Calling this automatically initializes the plugin. However plugins initialized this way
+   * <p>Calling this automatically initializes the plugin. However, plugins initialized this way
    * won't react to changes in activity or context, unlike {@link GeocodingPlugin}.
    */
-  public static void registerWith(Registrar registrar) {
+  @SuppressWarnings("deprecation")
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
     MethodCallHandlerImpl handler =
             new MethodCallHandlerImpl(new Geocoding(registrar.activeContext()));
     handler.startListening(registrar.messenger());

--- a/geocoding/example/android/app/build.gradle
+++ b/geocoding/example/android/app/build.gradle
@@ -27,6 +27,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 31
 
+    // Temporary add ndkVersion because GitHub CI is failing
+    // TODO (mvanbeusekom): Remove once NDK version 23 is supported
+    ndkVersion "22.1.7171670"
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/geocoding/example/android/app/src/main/AndroidManifest.xml
+++ b/geocoding/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="geocoding_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/geocoding/test/geocoding_test.dart
+++ b/geocoding/test/geocoding_test.dart
@@ -1,8 +1,5 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geocoding/geocoding.dart';
-import 'package:geocoding_platform_interface/geocoding_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Big fix

### :arrow_heading_down: What is the current behavior?

Compiling the Android example app results in an Android embedding deprecation warning.

### :new: What is the new behavior (if this is a feature change)?

Resolved the deprecated issue. Building the Android example App no longer results in the deprecation warning.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

```shell
# Change into the example folder
cd example
# Build the Android App
flutter build appbundle
```

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
