### PR TITLE
Fixes link to Android migration guide

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+- Fixes link to the Android migration guide in README.
+
 ## 2.0.3
 
 - Upgrades `compileSdkVersion` to `31` on Android.

--- a/geocoding/README.md
+++ b/geocoding/README.md
@@ -37,7 +37,7 @@ To use this plugin, please follow the installation guide on the [official geocod
 >  ...
 >}
 >```
->3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found here: https://developer.android.com/jetpack/androidx/migrate).
+>3. Make sure you replace all the `android.` dependencies to their AndroidX counterparts (a full list can be found [Android migration guide](https://developer.android.com/jetpack/androidx/migrate)).
 
 ## API
 

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
 
 environment:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Documentation update

### :arrow_heading_down: What is the current behavior?

The link to the Android migration guide is not working properly on pub.dev.

### :new: What is the new behavior (if this is a feature change)?

Restructure the link so it also works correctly on pub.dev.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

Solves #73 

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
