### PR TITLE
Update links for pub.dev

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5+1
+
+- Update pub.dev links
+
 ## 2.0.5
 
 - Fixed [#58](https://github.com/Baseflow/flutter-geocoding/issues/58) getting locationFromAddress freezes main thread.

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 2.0.5
+version: 2.0.5+1
 repository: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,7 +1,8 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
 version: 2.0.5
-homepage: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
+repository: https://github.com/baseflow/flutter-geocoding/tree/master/geocoding
+issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).


### :arrow_heading_down: What is the current behavior?

It shows a `Homepage` link


### :new: What is the new behavior (if this is a feature change)?

It shows links to `Repository (GitHub)` and `View/report issues`


### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] I made sure all projects build.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning).
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I followed the style guide lines ([code style guide](https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md)).
- [x] I updated the relevant documentation.
- [x] I rebased onto current `master`.
