### PR TITLE
Replace the stale both with more advanced version

### DIFF
--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -1,4 +1,4 @@
-name: No Response
+name: 'No Response'
 
 # Both `issue_comment` and `scheduled` event types are required for this Action
 # to work properly.
@@ -15,25 +15,16 @@ permissions:
   issues: write
 
 jobs:
-  noResponse:
+  stale:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'baseflow/flutter-geocoding' }}
     steps:
-      - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
+      - uses: actions/stale@v8
         with:
-          token: ${{ github.token }}
-          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
-          closeComment: >
-            Without additional information, we are unfortunately not sure how to
-            resolve this issue. We are therefore reluctantly going to close this
-            issue for now.
-            If you encounter this issue, please file a new issue with the same description,
-            what happens, logs and the output of 'flutter doctor -v'. All system setups
-            can be slightly different so it's always better to open new issues and reference
-            the related ones.
+          any-of-labels: 'status: needs more info'
+          close-issue-message: >
+            Without additional information, we are unfortunately not able to resolve this issue. 
+            Therefore, we reluctantly closed this issue for now. 
+            If you run into this issue later, feel free to file a new issue with a reference to this issue. 
+            Add a description of detailed steps to reproduce, expected and current behaviour, logs and the output of 'flutter doctor -v'. 
             Thanks for your contribution.
-          # Number of days of inactivity before an issue is closed for lack of response.
-          daysUntilClose: 14
-          # Label requiring a response.
-          responseRequiredLabel: "status: needs more info"
-          
+          days-before-close: 14


### PR DESCRIPTION
Replaces the `no-response` bot with a more advanced version. The main reason for this change is to make sure the bot also removes the `status: needs more info` label when other contributors post an update. 

The old bot only removed the label if the original poster responded, this might lead in issues being closed while sufficient information was provided.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geolocator/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
