### PR TITLE
Removes deprecation warnings. iOS 11 is minimal deployment target

### DIFF
--- a/geocoding_ios/CHANGELOG.md
+++ b/geocoding_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Removes deprecation warnings.
+
 ## 2.1.0
 
 * Splits from `geocoding` as a federated implementation.

--- a/geocoding_ios/CHANGELOG.md
+++ b/geocoding_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-* Removes deprecation warnings.
+* Removes obsolete version check in `toPlacemarkDictionary`. This removes [insert deprecation warning instance] from occurring.
 
 ## 2.1.0
 

--- a/geocoding_ios/CHANGELOG.md
+++ b/geocoding_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-* Removes obsolete version check in `toPlacemarkDictionary`. This removes [insert deprecation warning instance] from occurring.
+* Removes obsolete version check in `toPlacemarkDictionary`. This removes kABPersonAddressStreetKey deprecation warning from occurring.
 
 ## 2.1.0
 

--- a/geocoding_ios/ios/Classes/Extensions/CLPlacemarkExtensions.m
+++ b/geocoding_ios/ios/Classes/Extensions/CLPlacemarkExtensions.m
@@ -13,15 +13,9 @@
 
 - (NSDictionary *)toPlacemarkDictionary {
     NSString* street = @"";
-
-    if (@available(iOS 11.0, *)) {
-        if (self.postalAddress != nil) {
-            street = self.postalAddress.street;
-        }
-    } else if (@available(iOS 5.0, *)) {
-        if (self.addressDictionary != nil) {
-            street = [[self addressDictionary] objectForKey:(NSString *)kABPersonAddressStreetKey];
-        }
+    
+    if (self.postalAddress != nil) {
+        street = self.postalAddress.street;
     }
     
     NSMutableDictionary<NSString *, NSObject *> *dict = [[NSMutableDictionary alloc] initWithDictionary:@{

--- a/geocoding_ios/pubspec.yaml
+++ b/geocoding_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding_ios
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding_ios
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 


### PR DESCRIPTION
Resolves [142](https://github.com/Baseflow/flutter-geocoding/issues/142). Removed iOS deprecation warnings. Deleted code would never be used because the current minimal deployment target is 11.0. 

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
