### PR TITLE
Add support for `placemarkFromAddress` in platform interface

### DIFF
--- a/geocoding_platform_interface/CHANGELOG.md
+++ b/geocoding_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Adds `placemarkFromAddress` method to the platform interface.
+
 ## 3.0.0
 
 - **Breaking Change** Changes to the platform interface calls, the locale is now set in a separate call.

--- a/geocoding_platform_interface/lib/src/geocoding_platform_interface.dart
+++ b/geocoding_platform_interface/lib/src/geocoding_platform_interface.dart
@@ -72,4 +72,17 @@ abstract class GeocodingPlatform extends PlatformInterface {
     throw UnimplementedError(
         'placemarkFromCoordinates() has not been implementated.');
   }
+
+  /// Returns a list of [Placemark] instances found for the supplied address.
+  ///
+  /// In most situations the returned list should only contain one entry.
+  /// However in some situations where the supplied address could not be
+  /// resolved into a single [Placemark], multiple [Placemark] instances may be
+  /// returned.
+  Future<List<Placemark>> placemarkFromAddress(
+    String address,
+  ) {
+    throw UnimplementedError(
+        'placemarkFromAddress() has not been implementated.');
+  }
 }

--- a/geocoding_platform_interface/pubspec.yaml
+++ b/geocoding_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the geocoding plugin.
 homepage: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.0
+version: 3.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adds support for `placemarkFromAddress` in the geocoding platform interface.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
