### PR TITLE
Fixes 182 and removed deprecation warnings. Upgrades compileSDKVersion and adds support for Android 34.

### DIFF
--- a/geocoding_android/CHANGELOG.md
+++ b/geocoding_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0
+
+* **BREAKING CHANGES**:
+  * Updates `compileSdk' (compileSdkVersion) from 33 to 34.
+  * Fixes deprecation build warnings. 
+
 ## 3.0.0
 
 * **BREAKING CHANGES**:

--- a/geocoding_android/android/build.gradle
+++ b/geocoding_android/android/build.gradle
@@ -26,7 +26,7 @@ android {
         namespace("com.baseflow.geocoding")
     }
 
-    compileSdkVersion 33
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/geocoding_android/android/gradle.properties
+++ b/geocoding_android/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/geocoding_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/geocoding_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jan 30 14:47:38 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/geocoding_android/pubspec.yaml
+++ b/geocoding_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding_android
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 3.0.0
+version: 4.0.0
 repository: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding_android
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 


### PR DESCRIPTION
Fixes [182](https://github.com/Baseflow/flutter-geocoding/issues/182) adds support for Android 34

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
