### PR TITLE
Adds iOS privacy manifest.

### DIFF
--- a/geocoding_ios/CHANGELOG.md
+++ b/geocoding_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Adds privacy manifest.
+
 ## 3.0.0
 
 * **BREAKING CHANGES**:

--- a/geocoding_ios/ios/Resources/PrivacyInfo.xcprivacy
+++ b/geocoding_ios/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTracking</key>
+    <false/>
+</dict>
+</plist>

--- a/geocoding_ios/ios/geocoding_ios.podspec
+++ b/geocoding_ios/ios/geocoding_ios.podspec
@@ -20,4 +20,5 @@ A new flutter plugin project.
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.resource_bundles = {'geocoding_ios_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end

--- a/geocoding_ios/pubspec.yaml
+++ b/geocoding_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding_ios
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding_ios
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 
@@ -37,34 +37,3 @@ flutter:
       ios:
         pluginClass: GeocodingPlugin
         dartPluginClass: GeocodingIOS
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Adds the required privacy manifest to the iOS implementation.

Because the geocoding_ios package doesn't collect any privacy data, the privacy manifest can be empty. 

Note that we are following the standard Flutter / Cocoapods implementation which has the following caveat:

> The large caveat is that we do not currently know if this actually works. This is the method of inclusion that seems to be [the consensus among people using Cocoapods](https://github.com/CocoaPods/CocoaPods/issues/10325), as bundling it directly as a `resource` causes problems for clients who do not use `use_frameworks`. (In theory it seems like a manifest would not actually be *required* in that case since there is no framework, but it has the potential to actually stomp top-level resources.) Hopefully the automated analysis that Apple will eventually roll out will tolerate the file being bundled in a resource bundle in the framework rather than a top-level manifest file. If not, however, it's not clear how Cocoapods can be supported, so we can adopt this common approach for now under the assumption that eventually tooling will adapt to the reality of the ecosystem, and revisit the exact bundling later if necessary. 

Source: https://github.com/flutter/packages/commit/c5349bc9a5be1cbef9c13571d9d6d2b506240b20

Solves #207

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
