### PR TITLE
Removes references to Android v1 embedding.

### DIFF
--- a/geocoding_android/CHANGELOG.md
+++ b/geocoding_android/CHANGELOG.md
@@ -1,15 +1,19 @@
+## 3.3.1
+
+* Removes deprecated support for Android V1 embedding as support will be removed from Flutter (see [flutter/flutter#144726](https://github.com/flutter/flutter/pull/144726)).
+
 ## 3.3.0
 
-  * Added `setLocaleIdentifier` to the Android example app.
+* Adds `setLocaleIdentifier` to the Android example app.
 
 ## 3.2.0
 
-  * Exposes isPresent() call that returns true if there is a geocoder implementation present that may return results.
+* Exposes isPresent() call that returns true if there is a geocoder implementation present that may return results.
 
 ## 3.1.0
 
-  * Fixes deprecation build warnings. 
-  * Adds Android API 34 support.
+* Fixes deprecation build warnings. 
+* Adds Android API 34 support.
 
 ## 3.0.0
 

--- a/geocoding_android/android/src/main/java/com/baseflow/geocoding/GeocodingPlugin.java
+++ b/geocoding_android/android/src/main/java/com/baseflow/geocoding/GeocodingPlugin.java
@@ -15,20 +15,6 @@ public final class GeocodingPlugin implements FlutterPlugin {
   @Nullable private MethodCallHandlerImpl methodCallHandler;
   @Nullable private Geocoding geocoding;
 
-  /**
-   * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
-   * package.
-   *
-   * <p>Calling this automatically initializes the plugin. However, plugins initialized this way
-   * won't react to changes in activity or context, unlike {@link GeocodingPlugin}.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    MethodCallHandlerImpl handler =
-            new MethodCallHandlerImpl(new Geocoding(registrar.activeContext()));
-    handler.startListening(registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     geocoding = new Geocoding(binding.getApplicationContext());

--- a/geocoding_android/pubspec.yaml
+++ b/geocoding_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding_android
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 3.3.0
+version: 3.3.1
 repository: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding_android
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 


### PR DESCRIPTION
The Flutter team is removing references to the Android V1 embedding from their code base (see flutter/flutter#144726). This would mean that code still containing references to the Android V1 embedding will no longer compile. 

This PR removes references to Android V1 embedding from the permission_handler_android plugin.

- flutter/flutter#144726

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
