### PR TITLE
docs: use secure https link in README.md

### DIFF
--- a/geocoding/CHANGELOG.md
+++ b/geocoding/CHANGELOG.md
@@ -1,11 +1,15 @@
+## 3.0.1
+
+- Updated links in README.md to use `https` protocol.
+
 ## 3.0.0
 
-* **BREAKING CHANGES**:
+- **BREAKING CHANGES**:
   - Locale is no longer part of the `locationFromAddress` and `placemarkFromAddress`, but should be set first by `setLocaleIdentifier`. This was already implemented on Android but is now working similarly on iOS.
   - Updates documentation related to setting the locale.
   - Added `setLocaleIdentifier` to the example app.
   - Updates `geocoding_ios` version to 3.0.0.
-  
+
 ## 2.2.2
 
 - Updates documentation for isPresent().
@@ -23,16 +27,15 @@
 
 ## 2.2.0
 
-- Exposes the `isPresent()` method which on Android returns `true` if the 
-geocoding backend service are present on the device, otherwise returns `false`.
-On iOS this method always returns `true`.
+- Exposes the `isPresent()` method which on Android returns `true` if the
+  geocoding backend service are present on the device, otherwise returns `false`.
+  On iOS this method always returns `true`.
 
 ## 2.1.1
 
 - Updates the example app, so the `example/lib/main.dart` contains clear example
-code on how to use the geocoding plugin. Mean reason for doing so is that the 
-`example/lib/main.dart` is shown in the "Example" tab on pub.dev.
-  
+  code on how to use the geocoding plugin. Mean reason for doing so is that the
+  `example/lib/main.dart` is shown in the "Example" tab on pub.dev.
 
 ## 2.1.0
 

--- a/geocoding/README.md
+++ b/geocoding/README.md
@@ -57,7 +57,7 @@ import 'package:geocoding/geocoding.dart';
 List<Placemark> placemarks = await placemarkFromCoordinates(52.2165157, 6.9437819);
 ```
 
-The setLocaleIdentifier with the `localeIdentifier` parameter can be used to enforce the results to be formatted (and translated) according to the specified locale. The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode]. Use the [ISO 639-1 or ISO 639-2](http://www.loc.gov/standards/iso639-2/php/English_list.php) standard for the language code and the 2 letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) standard for the country code. Some examples are:
+The setLocaleIdentifier with the `localeIdentifier` parameter can be used to enforce the results to be formatted (and translated) according to the specified locale. The `localeIdentifier` should be formatted using the syntax: [languageCode]_[countryCode]. Use the [ISO 639-1 or ISO 639-2](https://www.loc.gov/standards/iso639-2/php/English_list.php) standard for the language code and the 2 letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) standard for the country code. Some examples are:
 
 Locale identifier | Description
 ----------------- | -----------

--- a/geocoding/pubspec.yaml
+++ b/geocoding/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geocoding
 description: A Flutter Geocoding plugin which provides easy geocoding and reverse-geocoding features.
-version: 3.0.0
+version: 3.0.1
 repository: https://github.com/baseflow/flutter-geocoding/tree/main/geocoding
 issue_tracker: https://github.com/Baseflow/flutter-geocoding/issues
 


### PR DESCRIPTION
Updated link in README.md file to use `https` (secure) instead of `http` (insecure) protocol.

Fixes the pub.dev score
<img width="526" alt="Screenshot 2024-08-23 at 2 22 44 AM" src="https://github.com/user-attachments/assets/6019e3a0-6692-433e-96f0-218166ee3ded">

## Pre-launch Checklist

- [ ] I made sure the project builds.
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I rebased onto `main`.
- [ ] I added new tests to check the change I am making, or this PR does not need tests.
- [ ] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [ ] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/flutter-geocoding/blob/master/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
