### PR TITLE
docs(readme): replace pub.dartlang.org with pub.dev; normalize macOS; update Flutter docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Flutter geocoding plugin
 
-[![pub package](https://img.shields.io/pub/v/geocoding.svg)](https://pub.dartlang.org/packages/geocoding)
+[![pub package](https://img.shields.io/pub/v/geocoding.svg)](https://pub.dev/packages/geocoding)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![style: effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://github.com/tenhobi/effective_dart)
 [![Buid status](https://github.com/Baseflow/flutter-geocoding/actions/workflows/geocoding.yaml/badge.svg)](https://github.com/Baseflow/flutter-geocoding/actions/workflows/geocoding.yaml)
 [![codecov](https://codecov.io/gh/Baseflow/flutter-geocoding/branch/main/graph/badge.svg)](https://codecov.io/gh/Baseflow/flutter-geocoding)
 
-The Flutter geocoding plugin is build following the federated plugin architecture. A detailed explanation of the federated plugin concept can be found in the [Flutter documentation](https://flutter.dev/docs/development/packages-and-plugins/developing-packages#federated-plugins). This means the geocoding plugin is separated into the following packages:
+The Flutter geocoding plugin is build following the federated plugin architecture. A detailed explanation of the federated plugin concept can be found in the [Flutter documentation](https://docs.flutter.dev/development/development/packages-and-plugins/developing-packages#federated-plugins). This means the geocoding plugin is separated into the following packages:
 
 1. [`geocoding`][1]: the app facing package. This is the package users depend on to use the plugin in their project. For details on how to use the [`geocoding`][1] plugin you can refer to its [README.md][2] file. At this moment the Android and iOS platform implementations are also part of this package;
 2. [`geocoding_platform_interface`][3]: this packages declares the interface which all platform packages must implement to support the app-facing package. Instructions on how to implement a platform packages can be found in the [README.md][4] of the [`geocoding_platform_interface`][3] package.


### PR DESCRIPTION
Small documentation cleanup in README:
- Replace legacy `pub.dartlang.org` links with `pub.dev`
- Normalize platform spelling `MacOS` -> `macOS`
- Update `flutter.dev/docs/...` links to `docs.flutter.dev/...`

No code changes.